### PR TITLE
lnic.h compiles with C++ compiler

### DIFF
--- a/tests/encoding.h
+++ b/tests/encoding.h
@@ -166,31 +166,31 @@
 
 #ifdef __GNUC__
 
-#define read_csr(reg) ({ unsigned long __tmp; \
+#define read_csr(reg) __extension__({ unsigned long __tmp; \
   asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
   __tmp; })
 
-#define write_csr(reg, val) ({ \
+#define write_csr(reg, val) __extension__({ \
   if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
     asm volatile ("csrw " #reg ", %0" :: "i"(val)); \
   else \
     asm volatile ("csrw " #reg ", %0" :: "r"(val)); })
 
-#define swap_csr(reg, val) ({ unsigned long __tmp; \
+#define swap_csr(reg, val) __extension__({ unsigned long __tmp; \
   if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
     asm volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "i"(val)); \
   else \
     asm volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "r"(val)); \
   __tmp; })
 
-#define set_csr(reg, bit) ({ unsigned long __tmp; \
+#define set_csr(reg, bit) __extension__({ unsigned long __tmp; \
   if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
     asm volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "i"(bit)); \
   else \
     asm volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "r"(bit)); \
   __tmp; })
 
-#define clear_csr(reg, bit) ({ unsigned long __tmp; \
+#define clear_csr(reg, bit) __extension__({ unsigned long __tmp; \
   if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
     asm volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "i"(bit)); \
   else \

--- a/tests/lnic.h
+++ b/tests/lnic.h
@@ -21,7 +21,7 @@
 #define lnic_ready() (read_csr(0x52) != 0)
 #define lnic_idle() write_csr(0x56, 2)
 
-#define lnic_read() ({ uint64_t __tmp; \
+#define lnic_read() __extension__({ uint64_t __tmp; \
   asm volatile ("mv %0, " LREAD  : "=r"(__tmp)); \
   __tmp; })
 #define lnic_copy() asm volatile ("mv " LWRITE ", " LREAD)

--- a/tests/lnic.h
+++ b/tests/lnic.h
@@ -12,7 +12,7 @@
 #define CONTEXT_MASK 0x00000000ffff0000
 #define LEN_MASK     0x000000000000ffff
 
-#define lnic_add_context(cid, priority) ({ write_csr(0x053, cid); write_csr(0x055, priority); write_csr(0x054, 1); })
+#define lnic_add_context(cid, priority) __extension__({ write_csr(0x053, cid); write_csr(0x055, priority); write_csr(0x054, 1); })
 
 #define lnic_msg_done() write_csr(0x056, 1)
 
@@ -22,15 +22,15 @@
 #define lnic_idle() write_csr(0x56, 2)
 
 #define lnic_read() ({ uint64_t __tmp; \
-  asm volatile ("mv %0, "LREAD  : "=r"(__tmp)); \
+  asm volatile ("mv %0, " LREAD  : "=r"(__tmp)); \
   __tmp; })
-#define lnic_copy() asm volatile ("mv "LWRITE", "LREAD)
-#define lnic_add_int_i(val)  asm volatile ("add "LWRITE", "LREAD", %0" : /*no outputs*/ : "i"(val))
-#define lnic_write_r(val) asm volatile ("mv "LWRITE", %0" : /*no outputs*/ : "r"(val))
-#define lnic_write_i(val) asm volatile ("li "LWRITE", %0" : /*no outputs*/ : "i"(val))
-#define lnic_write_m(val) asm volatile ("ld "LWRITE", %0" : /*no outputs*/ : "m"(val))
+#define lnic_copy() asm volatile ("mv " LWRITE ", " LREAD)
+#define lnic_add_int_i(val)  asm volatile ("add " LWRITE ", " LREAD ", %0" : /*no outputs*/ : "i"(val))
+#define lnic_write_r(val) asm volatile ("mv " LWRITE ", %0" : /*no outputs*/ : "r"(val))
+#define lnic_write_i(val) asm volatile ("li " LWRITE ", %0" : /*no outputs*/ : "i"(val))
+#define lnic_write_m(val) asm volatile ("ld " LWRITE ", %0" : /*no outputs*/ : "m"(val))
 
-#define lnic_branch(inst, val, target) asm goto (inst" %0, "LREAD", %1\n\t" : /*no outputs*/ : "r"(val) : /*no clobbers*/ : target)
+#define lnic_branch(inst, val, target) asm goto (inst" %0, " LREAD ", %1\n\t" : /*no outputs*/ : "r"(val) : /*no clobbers*/ : target)
 
 #define lnic_boot() lnic_write_i(16); lnic_write_i(0); lnic_write_i(0)
 


### PR DESCRIPTION
I added some spaces to the literals to get `lnic.h` to compile with cpp. This fixes the following types of errors:
```
lnic.h:27:41: error: invalid suffix on literal; C++11 requires a space between literal and string macro [-Werror=literal-suffix]
   27 | #define lnic_write_r(val) asm volatile ("mv "LWRITE", %0" : /*no outputs*/ : "r"(val))
      |                                         ^
encoding.h:173:29: error: ISO C++ forbids braced-groups within expressions [-Werror=pedantic]
  173 | #define write_csr(reg, val) ({ \
      |                             ^
```